### PR TITLE
Fix the idiosyncratic "no atoms??" error message.

### DIFF
--- a/pd.lua
+++ b/pd.lua
@@ -324,6 +324,9 @@ function pd.Class:dispatch(inlet, sel, atoms)
 end
 
 function pd.Class:outlet(outlet, sel, atoms)
+  if type(atoms) ~= "table" then
+     atoms = {atoms}
+  end
   pd._outlet(self._object, outlet, sel, atoms)
 end
 


### PR DESCRIPTION
This Lua error appears if the atoms argument to pd.Class:outlet is anything but a table. The fix is trivial: Check that the atoms argument actually is a table, and, if this is not the case, either output a more helpful error message, or just turn the singleton into a table with one element (which is what we do here).

I'm not sure that I actually want to fix this. It's one of pdlua's funny quirks which I actually discuss in the [tutorial](https://agraef.github.io/pd-lua/tutorial/pd-lua-intro.html#lua-errors) in order to illustrate what happens if something goes wrong deep down in pdlua's internals.