### PR TITLE
Make path to Makefile.pdlibbuilder settable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.git*      	export-ignore
+.travis.yml	export-ignore

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,13 @@ pdlua_version := $(shell git describe --tags 2>/dev/null)
 
 luasrc = $(wildcard lua/onelua.c)
 
+PKG_CONFIG ?= pkg-config
+
 ifeq ($(luasrc),)
 # compile with installed liblua
 $(info ++++ NOTE: using installed lua)
-luaflags = $(shell pkg-config --cflags lua)
-lualibs = $(shell pkg-config --libs lua)
+luaflags = $(shell $(PKG_CONFIG) --cflags lua)
+lualibs = $(shell $(PKG_CONFIG) --libs lua)
 else
 # compile with Lua submodule
 $(info ++++ NOTE: using lua submodule)

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ pdlua.class.ldlibs := $(lualibs)
 
 datafiles = pd.lua $(wildcard pdlua*-help.pd)
 
-include Makefile.pdlibbuilder
+PDLIBBUILDER_DIR=.
+include $(PDLIBBUILDER_DIR)/Makefile.pdlibbuilder
 
 install: installplus
 


### PR DESCRIPTION
Closes: https://github.com/agraef/pd-lua/issues/32

the 2nd commit excludes the `.gitmodules` file  (and `.github/` directory) from the generated source tarballs.
(the reasoning is: if you want all the git-nifties of this repository, you should probably just clone the repository; but if you are using the source-tarballs for downstream packaging *and* `git` to manage the packaging, upstream repository config usually gets in the way badly)

the 3rd commit allows packagers to override the `pkg-config` script, which helps when cross-compiling.