### PR TITLE
Windows fixes for randomness and hi-dpi scaling

### DIFF
--- a/pdlua.h
+++ b/pdlua.h
@@ -31,9 +31,9 @@ typedef struct _pdlua_gfx
 {
 #if !PLUGDATA
     char object_tag[128]; // Tcl/tk tag that is attached to all drawings
-    char order_tag[128]; // Tag for invisible line, used to preserve correct object ordering
-    char current_paint_tag[128]; // Tcl/tk tag that is only attached to the current drawing in progress
-            
+    char order_tag[64]; // Tag for invisible line, used to preserve correct object ordering
+    char current_paint_tag[64]; // Tcl/tk tag that is only attached to the current drawing in progress
+    
     // Variables to keep track of mouse button state and drag position
     int mouse_drag_x, mouse_drag_y, mouse_down;
     

--- a/pdlua_gfx.h
+++ b/pdlua_gfx.h
@@ -1008,10 +1008,12 @@ static int draw_text(lua_State* L) {
     int x = luaL_checknumber(L, 2);
     int y = luaL_checknumber(L, 3);
     int w = luaL_checknumber(L, 4);
-    int fontHeight = luaL_checknumber(L, 5);
+    int font_height = luaL_checknumber(L, 5);
+    font_height = sys_hostfontsize(font_height, glist_getzoom(cnv));
+    font_height *= 0.75f; // Make font size smaller to match the size in plugdata
     
     transform_point(gfx, &x, &y);
-    transform_size(gfx, &w, &fontHeight);
+    transform_size(gfx, &w, &font_height);
     
     int canvas_zoom = glist_getzoom(cnv);
     x += text_xpix((t_object*)obj, obj->canvas) / canvas_zoom;
@@ -1021,9 +1023,6 @@ static int draw_text(lua_State* L) {
     y *= canvas_zoom;
     w *= canvas_zoom;
     
-    // Font size is offset to make sure it matches the size in plugdata
-    fontHeight *= 0.8f;
-    
     const char* tags[] = { gfx->object_tag, register_drawing(obj) };
     
     pdgui_vmess(0, "crr ii rs ri rs rS", cnv, "create", "text",
@@ -1031,7 +1030,7 @@ static int draw_text(lua_State* L) {
 
     t_atom fontatoms[3];
     SETSYMBOL(fontatoms+0, gensym(sys_font));
-    SETFLOAT (fontatoms+1, font_height);
+    SETFLOAT (fontatoms+1, -font_height); // Size is wrong on hi-dpi Windows is this is not negative
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
     pdgui_vmess(0, "crs rA rs rs", cnv, "itemconfigure", tags[1],


### PR DESCRIPTION
Fixes 2 problems on Windows:

- Better random string generation, which fixes #39. We now have a string with 61 random alphanumeric chars (also using a better random algorithm), which should give plenty of randomness.

- Fontheight needs to be passed to tcl/tk as a negative value to get it to scale along with hi-dpi screens on Windows. This is done in other places in pd's source code as well, like [here](https://github.com/pure-data/pure-data/blob/0259d00373b9e6f3bc1d76eebc5b243283ca7063/src/g_all_guis.c#L543)