### PR TITLE
add deken test/upload, pd0.55-0, 64bit builds, update pdlibbuilder

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,7 +2,7 @@ name: Makefile CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, build-tests ]
     tags: [ '*' ]
   pull_request:
     branches: [ master ]
@@ -11,9 +11,12 @@ jobs:
   ubuntu-build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        floatsize: [32, 64]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 0
@@ -22,71 +25,76 @@ jobs:
       run: sudo apt install puredata-dev
 
     - name: make
-      run: make
-
-    - name: make install
-      run: make install objectsdir=./build
+      run: make install objectsdir=./build floatsize=${{ matrix.floatsize }} extension=linux-amd64-${{ matrix.floatsize }}.so
 
     - name: upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: pdlua-ubuntu
+        name: pdlua-ubuntu-pd${{ matrix.floatsize }}
         path: build
 
   macos-build:
 
     runs-on: macos-latest
+    strategy:
+      matrix:
+        floatsize: [32, 64]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 0
 
     - name: install dependencies
       run: |
-        wget https://github.com/pure-data/pure-data/archive/refs/tags/0.53-1.zip
-        unzip 0.53-1.zip
+        wget https://github.com/pure-data/pure-data/archive/refs/tags/0.55-0.zip
+        unzip 0.55-0.zip
 
     - name: make
-      run: make PDDIR=./pure-data-0.53-1 arch="arm64 x86_64"
-
-    - name: make install
-      run: make install objectsdir=./build
+      run: make install objectsdir=./build PDDIR=./pure-data-0.55-0 arch="arm64 x86_64" floatsize=${{ matrix.floatsize }} extension=darwin-fat-${{ matrix.floatsize }}.so
 
     - name: upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: pdlua-macos
+        name: pdlua-macos-pd${{ matrix.floatsize }}
         path: build
 
   windows-build:
 
     runs-on: windows-2019
+    strategy:
+      matrix:
+        floatsize: [32, 64]
     env:
       CC: gcc
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 0
 
-    - name: install dependencies
+    - name: install dependencies for 32-bit
+      if: matrix.floatsize == 32
       run: |
         C:\msys64\usr\bin\wget.exe http://msp.ucsd.edu/Software/pd-0.55-0.msw.zip
         unzip pd-0.55-0.msw.zip
 
-    - name: make
-      run: make PDDIR=./pd-0.55-0
+    - name: install dependencies for 64-bit
+      if: matrix.floatsize == 64
+      run: | # unfortunately, the folder name convention is slightly different here
+        C:\msys64\usr\bin\wget.exe https://puredata.info/downloads/pure-data/releases/0.55-0-pd64/Pd64-0.55-0.msw.zip
+        unzip Pd64-0.55-0.msw.zip
+        ren Pd-0.55.0 pd-0.55-0
 
-    - name: make install
-      run: make install objectsdir=./build
+    - name: make 32-bit
+      run: make install objectsdir=./build PDDIR=./pd-0.55-0 PDINCLUDEDIR=./pd-0.55-0/src PDBINDIR=./pd-0.55-0/bin floatsize=${{ matrix.floatsize }} extension=windows-amd64-${{ matrix.floatsize }}.dll
 
     - name: upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: pdlua-windows
+        name: pdlua-windows-pd${{ matrix.floatsize }}
         path: build
 
 # Big thanks to @tomara-x and @timothyschoen for showing me how to do this! -ag
@@ -96,14 +104,102 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ubuntu-build, macos-build, windows-build]
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
     - name: ziptie
       run: |
         mkdir dist
         for x in pdlua-*; do (cd $x && zip -r ../dist/$x.zip pdlua/); done
     - name: release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         prerelease: true
         draft: true
         files: dist/*.zip
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: [ubuntu-build, macos-build, windows-build]
+    permissions:
+      contents: write
+      actions: read
+    strategy:
+      matrix:
+        os: [windows, macos, ubuntu]
+    steps:
+      - name: Download Artifacts # FIXME: currently downloads all artifacts redundantly for each OS
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Merge Artifacts to Package
+        run: cp -rn artifacts/pdlua-${{ matrix.os }}*/* .
+
+      - name: Upload Package
+        uses: actions/upload-artifact@v4
+        with:
+          name: pdlua-${{ matrix.os }}
+          path: pdlua
+
+  deken_check_and_upload:
+    runs-on: ubuntu-latest
+    needs: [merge]
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: pdlua-src
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: pdlua-windows
+          path: pdlua-windows
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: pdlua-macos
+          path: pdlua-macos
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: pdlua-ubuntu
+          path: pdlua-ubuntu
+
+      - name: Check Deken Package
+        shell: bash
+        run: |
+          SHORT=${GITHUB_REF:10}
+          VERSION=${SHORT//\//_}
+          for os in ubuntu macos windows; do
+            echo "## ${os}" | tee -a $GITHUB_STEP_SUMMARY
+            mkdir -p package-${os}
+            docker run --rm --user $(id -u) --volume ./pdlua-${os}:/pdlua \
+              --volume ./package-${os}:/package registry.git.iem.at/pd/deken \
+              deken package --output-dir /package -v "${VERSION}" /pdlua
+
+            dek_files=$(ls package-${os}/*.dek)
+            for dek_file in $dek_files; do
+              filename=$(basename "$dek_file")
+              echo -e "#### \`$filename\`" | tee -a $GITHUB_STEP_SUMMARY
+              echo '```' | tee -a $GITHUB_STEP_SUMMARY
+              unzip -l "$dek_file" | awk 'NR>3 {print $4}' | sed '/^$/d' | sort | tee -a $GITHUB_STEP_SUMMARY
+              echo '```' | tee -a $GITHUB_STEP_SUMMARY
+            done
+          done
+
+      - name: Upload Deken Package
+        if: ${{ !contains(github.ref, 'test') }} # upload if not a "test" release
+        shell: bash
+        env:
+          DEKEN_USERNAME: ${{ secrets.DEKEN_USERNAME }}
+          DEKEN_PASSWORD: ${{ secrets.DEKEN_PASSWORD }}
+        run: |
+          SHORT=${GITHUB_REF:10}
+          VERSION=${SHORT//\//_}
+          for os in ubuntu macos windows; do
+            docker run --rm -e DEKEN_USERNAME -e DEKEN_PASSWORD \
+              --volume ./pdlua-${os}:/pdlua registry.git.iem.at/pd/deken \
+              deken upload --no-source-error -v "${VERSION}" /pdlua
+          done
+          docker run --rm -e DEKEN_USERNAME -e DEKEN_PASSWORD \
+            --volume ./pdlua-src:/pdlua registry.git.iem.at/pd/deken \
+            deken upload -v "${VERSION}" /pdlua

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -1,5 +1,5 @@
 # Makefile.pdlibbuilder dated 2019-12-21
-version = 0.6.0
+version = 0.7.0
 
 # Helper makefile for Pure Data external libraries.
 # Written by Katja Vetter March-June 2015 for the public domain. No warranties.
@@ -102,6 +102,8 @@ version = 0.6.0
 # Optional user variables for make command line or environment:
 #
 # - PLATFORM
+# - extension
+# - floatsize
 #
 # Deprecated path variables:
 #
@@ -204,6 +206,19 @@ version = 0.6.0
 # pdlibbuilder will use, if installed and locatable. System and architecture
 # will then be autodefined accordingly. In most cases no other variables need to
 # be overridden.
+#
+# extension:
+# Extension for the external to use. Example: m_amd64
+# A sane default is picked, but it is useful if you want to provide
+# co-installable externals for multiple platforms (for the same operating
+# systems)
+#
+# floatsize:
+# the size of the t_float in bits. Example: 32
+# t_float are usually single precision (32bit), which is the default.
+# For double precision use floatsize=64
+# When building double precision externals, you will want to set the extension
+# as well, e.g. extension=windows-amd64-64.dll (<system>-<cpu>-<floatsize>.<ext>)
 #
 # CPPFLAGS:
 # Preprocessor flags which are not strictly required for building.
@@ -442,6 +457,14 @@ target.arch := $(firstword $(target.triplet))
 ### variables per platform #####################################################
 ################################################################################
 
+#=== flags per floatsize == ====================================================
+floatsize = 32
+ifneq ($(filter-out 32,$(floatsize)),)
+  floatsize.flags = -DPD_FLOATSIZE=$(floatsize)
+else
+  floatsize.flags =
+endif
+
 
 #=== flags per architecture ====================================================
 
@@ -584,14 +607,14 @@ ifeq ($(system), Windows)
   extension = dll
   c.flags :=
   c.ldflags := -static-libgcc -shared \
-    -Wl,--enable-auto-import "$(PDBINDIR)/pd.dll"
+    -Wl,--enable-auto-import "$(PDBINDIR)/pd$(filter-out 32,$(floatsize)).dll"
   c.ldlibs :=
   cxx.flags := -fcheck-new
   cxx.ldflags := -static-libgcc -static-libstdc++ -shared \
-    -Wl,--enable-auto-import "$(PDBINDIR)/pd.dll"
+    -Wl,--enable-auto-import "$(PDBINDIR)/pd$(filter-out 32,$(floatsize)).dll"
   cxx.ldlibs :=
   shared.extension = dll
-  shared.ldflags := -static-libgcc -shared "$(PDBINDIR)/pd.dll"
+  shared.ldflags := -static-libgcc -shared "$(PDBINDIR)/pd$(filter-out 32,$(floatsize)).dll"
   stripflags = --strip-all
 endif
 
@@ -639,7 +662,7 @@ endif
 CFLAGS = $(warn.flags) $(optimization.flags) $(arch.c.flags)
 
 # preprocessor flags
-cpp.flags := -DPD -I "$(PDINCLUDEDIR)" $(cpp.flags) $(CPPFLAGS)
+cpp.flags := -DPD -I "$(PDINCLUDEDIR)" $(floatsize.flags) $(cpp.flags) $(CPPFLAGS)
 
 # flags for dependency checking (cflags from makefile may define -I options)
 depcheck.flags := $(cpp.flags) $(cflags)
@@ -683,6 +706,7 @@ endif
 ### variables: files ###########################################################
 ################################################################################
 
+object.extension = $(extension).o
 
 #=== sources ===================================================================
 
@@ -709,10 +733,10 @@ all.sources := $(classes.sources) $(lib.setup.sources) \
 
 
 # construct object filenames from all C and C++ source file names
-classes.objects := $(addsuffix .o, $(basename $(classes.sources)))
-common.objects := $(addsuffix .o, $(basename $(common.sources)))
-shared.objects := $(addsuffix .o, $(basename $(shared.sources)))
-lib.setup.objects := $(addsuffix .o, $(basename $(lib.setup.sources)))
+classes.objects := $(addsuffix .$(object.extension), $(basename $(classes.sources)))
+common.objects := $(addsuffix .$(object.extension), $(basename $(common.sources)))
+shared.objects := $(addsuffix .$(object.extension), $(basename $(shared.sources)))
+lib.setup.objects := $(addsuffix .$(object.extension), $(basename $(lib.setup.sources)))
 all.objects = $(classes.objects) $(common.objects) $(shared.objects) \
   $(lib.setup.objects)
 
@@ -723,12 +747,13 @@ all.objects = $(classes.objects) $(common.objects) $(shared.objects) \
 # construct class executable names from class names
 classes.executables := $(addsuffix .$(extension), $(classes))
 
-# Construct shared lib executable name if shared sources are defined. If
-# extension and shared extension are not identical, use both to facilitate co-
-# installation for different platforms, like .m_i386.dll and .m_amd64.dll.
+# Construct shared lib executable name if shared sources are defined.
+# If extension does not end with shared extension, use both to facilitate co-
+# installation for different platforms, like .m_i386.dll and .linux-amd64-32.so
 ifdef shared.sources
-  ifeq ($(extension), $(shared.extension))
-    shared.lib = lib$(lib.name).$(shared.extension)
+  ifneq ($(filter %.$(shared.extension), .$(extension)), )
+    # $(extension) already ends with $(shared.extension), no need to duplicate it
+    shared.lib = lib$(lib.name).$(extension)
   else
     shared.lib = lib$(lib.name).$(extension).$(shared.extension)
   endif
@@ -790,7 +815,7 @@ endif
 
 # store path to pd.dll; if not found, ls will give a useful error
 ifeq ($(system), Windows)
-  pddll := $(shell ls "$(PDBINDIR)/pd.dll")
+  pddll := $(shell ls "$(PDBINDIR)/pd$(filter-out 32,$(floatsize)).dll")
 endif
 
 # when making target all, check if m_pd.h is found and print info about it
@@ -874,8 +899,8 @@ define link-class
   $(compile-$1) \
   $($1.ldflags) $($2.class.ldflags) \
   -o $2.$(extension) \
-  $(addsuffix .o, $(basename $($2.class.sources))) \
-  $(addsuffix .o, $(basename $(common.sources))) \
+  $(addsuffix .$(object.extension), $(basename $($2.class.sources))) \
+  $(addsuffix .$(object.extension), $(basename $(common.sources))) \
   $($1.ldlibs) $($2.class.ldlibs) $(shared.lib)
 endef
 
@@ -949,13 +974,13 @@ endef
 # Three rules to create .o files. These are double colon 'terminal' rules,
 # meaning they are the last in a rules chain.
 
-%.o:: %.c
+%.$(object.extension):: %.c
 	$(call make-object-file,c)
 
-%.o:: %.cc
+%.$(object.extension):: %.cc
 	$(call make-object-file,cxx)
 
-%.o:: %.cpp
+%.$(object.extension):: %.cpp
 	$(call make-object-file,cxx)
 
 
@@ -974,8 +999,8 @@ endef
 # declare explicit prerequisites rule like 'class.extension: object1.o object2.o'
 # argument $v is class basename
 define declare-class-executable-target
-$v.$(extension): $(addsuffix .o, $(basename $($v.class.sources))) \
-  $(addsuffix .o, $(basename $(common.sources)))
+$v.$(extension): $(addsuffix .$(object.extension), $(basename $($v.class.sources))) \
+  $(addsuffix .$(object.extension), $(basename $(common.sources)))
 endef
 
 # evaluate explicit prerequisite rules for all classes
@@ -1005,7 +1030,7 @@ endif
 # argument $1 is input source file(s)
 # dir is explicitly added because option -MM strips it by default
 define declare-object-target
-$(dir $1)$(filter %.o: %.h, $(shell $(CPP) $(depcheck.flags) -MM $1)) $(MAKEFILE_LIST)
+$(dir $1)$(patsubst %.o:,%.$(object.extension):,$(filter %.o: %.h, $(shell $(CPP) $(depcheck.flags) -MM $1))) $(MAKEFILE_LIST)
 endef
 
 # evaluate implicit prerequisite rules when rebuilding everything


### PR DESCRIPTION
* version tags (like `0.12.4` will automatically trigger uploads to deken)
* if the tag contains the string `test`, the deken packages will still be created and a content list is printed to the workflow summary - but they're not uploaded
* builds are created for Pd and Pd64 (which was simple after the pdlibbuilder update)
* the builds are made against pd0.55-0 now

the current v0.12.4 on deken was uploaded by this workflow and is tested on windows (amd64) and macos (arm64 and amd64) with pd and pd64. additional tests on linux might be nice.

deken uploads require the repository secrets `DEKEN_USERNAME` and `DEKEN_PASSWORD`