### PR TITLE
expose Pd's canvas_realizedollar() and modify set_args() for dollar arguments

### DIFF
--- a/pd.lua
+++ b/pd.lua
@@ -453,6 +453,10 @@ function pd.Class:set_args(args)
     pd._set_args(self._object, args)
 end
 
+function pd.Class:canvas_realizedollar(s)
+    return pd._canvas_realizedollar(self._object, s)
+end
+
 function pd.Class:repaint()
   if type(self.paint) == "function" then
     local g = _gfx_internal.start_paint(self._object);

--- a/pdlua.c
+++ b/pdlua.c
@@ -2490,6 +2490,23 @@ static int pdlua_dofile(lua_State *L)
     return lua_gettop(L) - n;
 }
 
+static int pdlua_canvas_realizedollar(lua_State *L)
+{
+    if (lua_islightuserdata(L, 1) && lua_isstring(L, 2))
+    {
+        t_pdlua *o = lua_touserdata(L, 1);
+        if (o && o->canvas)
+        {
+            const char *sym_name = lua_tostring(L, 2);
+            t_symbol *s = gensym(sym_name);
+            t_symbol *result = canvas_realizedollar(o->canvas, s);
+            lua_pushstring(L, result->s_name);
+            return 1;
+        }
+    }
+    return 0;
+}
+
 /** Initialize the pd API for Lua. */
 static void pdlua_init(lua_State *L)
 /**< Lua interpreter state. */
@@ -2584,6 +2601,9 @@ static void pdlua_init(lua_State *L)
     lua_settable(L, -3);
     lua_pushstring(L, "_set_args");
     lua_pushcfunction(L, pdlua_set_arguments);
+    lua_settable(L, -3);
+    lua_pushstring(L, "_canvas_realizedollar");
+    lua_pushcfunction(L, pdlua_canvas_realizedollar);
     lua_settable(L, -3);
     lua_pushstring(L, "_error");
     lua_pushcfunction(L, pdlua_error);

--- a/pdlua.c
+++ b/pdlua.c
@@ -1184,11 +1184,12 @@ static int pdlua_set_arguments(lua_State *L)
                     binbuf_add(b, 1, &atom);
                 }
                 else if (lua_isstring(L, -1)) {
-                    // If it's a string, convert it to a symbol and add to binbuf
+                    // If it's a string, parse it using binbuf_text and add the resulting atoms to the binbuf
                     const char* str = lua_tostring(L, -1);
-                    t_atom atom;
-                    SETSYMBOL(&atom, gensym(str));
-                    binbuf_add(b, 1, &atom);
+                    t_binbuf *temp = binbuf_new();
+                    binbuf_text(temp, str, strlen(str));
+                    binbuf_add(b, binbuf_getnatom(temp), binbuf_getvec(temp));
+                    binbuf_free(temp);
                 }
 
                 // Pop the value from the stack


### PR DESCRIPTION
creating this PR here mainly to summarize the result of https://github.com/agraef/pd-lua/issues/52, which escalated a bit. these changes certainly require review, and it's obviously also no problem if this PR is declined or needs further modifications.

#### the primary goal was:
* enable pdlua externals to have their senders and receivers set through messages, similar to iemguis and other externals.

#### changes:
1. writing the necessary `\$0-name` string to the pd file isn't possible with `set_args()` as it also escapes the backslash to `\\\$0-name`. this is addressed with 48f00537b04ef2100e10c7e52aaec877b4b32d0d
2. for the pdlua object to apply the given receiver name immediately, an API method to expand it is required. this functionality is implemented with 53f0342b1db016c5e1112e10b63532c4f5e7aefb

#### findings that may require further consideration:
1. when a dollar argument can't be expanded, it remains a dollar argument (in lua, it will just be a `"$1"` string then, for example)
2. sending `\$01` from pd in that case will also result in `"$1"` on the lua side however

i've tested these changes in my setup without encountering issues so far. to facilitate testing elsewhere, i'm attaching these files (pdlua object and patch): [test_dollar.zip](https://github.com/user-attachments/files/17049903/test_dollar.zip)
