### PR TITLE
add optional alignment arg to draw_text

### DIFF
--- a/pd.lua
+++ b/pd.lua
@@ -628,6 +628,17 @@ DATA = 0
 SIGNAL = 1
 Colors = {background = 0, foreground = 1, outline = 2}
 
+-- Text alignment constants
+TOP_LEFT = 0
+TOP_CENTER = 1
+TOP_RIGHT = 2
+CENTER_LEFT = 3
+CENTER = 4
+CENTER_RIGHT = 5
+BOTTOM_LEFT = 6
+BOTTOM_CENTER = 7
+BOTTOM_RIGHT = 8
+
 -- pre-load pdx.lua (advanced live coding support); if you don't want this,
 -- just comment out the line below
 pdx = require 'pdx'

--- a/pdlua_gfx.h
+++ b/pdlua_gfx.h
@@ -1289,10 +1289,9 @@ static int draw_text(lua_State* L) {
     int x = luaL_checknumber(L, 2);
     int y = luaL_checknumber(L, 3);
     int w = luaL_checknumber(L, 4);
-    int font_height = luaL_checknumber(L, 5);
-    font_height = sys_hostfontsize(font_height, glist_getzoom(cnv));
+    int font_height = sys_hostfontsize(luaL_checknumber(L, 5), glist_getzoom(cnv));
+    int alignment = luaL_optinteger(L, 6, 0); // Defaults to TOP_LEFT
 
-    int alignment = lua_gettop(L) >= 6 ? luaL_checkinteger(L, 6) : 0; // Default to TOP_LEFT
     transform_point(gfx, &x, &y);
     transform_size(gfx, &w, &font_height);
 


### PR DESCRIPTION
closes #64

only handles the additional argument for vanilla.
opening this PR for further discussion since i'm not sure if that's "the way".