### PR TITLE
Add mouse_enter() and mouse_exit() for Pd vanilla

### DIFF
--- a/pd.lua
+++ b/pd.lua
@@ -115,6 +115,12 @@ pd._mouseevent = function (object, x, y, event_type)
     if event_type == 3 and type(obj.mouse_drag) == "function" then
       obj:mouse_drag(x, y)
     end
+    if event_type == 4 and type(obj.mouse_enter) == "function" then
+      obj:mouse_enter(x, y)
+    end
+    if event_type == 5 and type(obj.mouse_exit) == "function" then
+      obj:mouse_exit(x, y)
+    end
   end
 end
 

--- a/pdlua.c
+++ b/pdlua.c
@@ -581,6 +581,7 @@ static void pdlua_proxyclock_setup(void)
 /** Setup the proxy class for canvas events. */
 static void pdlua_proxycanvas_setup(void)
 {
+#if !PLUGDATA
     pdlua_proxycanvas_class = class_new(
         gensym("pdlua proxy canvas"), 0,
         (t_method)pdlua_proxycanvas_free,
@@ -589,6 +590,7 @@ static void pdlua_proxycanvas_setup(void)
         0);        
     if (pdlua_proxycanvas_class)
         class_addanything(pdlua_proxycanvas_class, (t_method)pdlua_proxycanvas_anything);
+#endif
 }
 
 /** Dump an array of atoms into a Lua table. */
@@ -811,7 +813,7 @@ static t_pdlua *pdlua_new
         if (lua_islightuserdata(__L(), -1))
         {
             object = lua_touserdata(__L(), -1);
-            
+#if !PLUGDATA
             // Create canvas proxy if we have GUI
             if (object->has_gui) {
                 t_canvas *parent_canvas = glist_getcanvas(object->canvas);
@@ -825,7 +827,7 @@ static t_pdlua *pdlua_new
                     return NULL;
                 }
             }
-            
+#endif
             lua_pop(__L(), 2);/* pop the userdata and the global "pd" */
             PDLUA_DEBUG2("pdlua_new: before returning object %p stack top %d", object, lua_gettop(__L()));
             return object;
@@ -892,11 +894,13 @@ static void pdlua_delete(t_gobj *z, t_glist *glist) {
     
     canvas_deletelinesfor(glist, (t_text *)z);
     
+#if !PLUGDATA
     if (x->gfx.proxycanvas) {
         // Schedule deferred cleanup (similar to receivecanvas external code)
         clock_delay(x->gfx.proxycanvas->p_clock, 0);
         x->gfx.proxycanvas = NULL;
     }
+#endif
 }
 
 #ifdef PURR_DATA // Purr Data uses an older version of this API

--- a/pdlua.h
+++ b/pdlua.h
@@ -42,9 +42,10 @@ typedef struct _pdlua_gfx
     int num_transforms;
     char current_color[10]; // Keep track of current color
     
-    // Variables to keep track of mouse button state and drag position
-    int mouse_x, mouse_y, mouse_down;
+    // Variables to keep track of mouse position, button state and whether the mouse is inside the object
+    int mouse_x, mouse_y, mouse_down, mouse_inside;
     int first_draw;
+    struct pdlua_proxycanvas *proxycanvas;
 #else
     int current_layer;
     void(*plugdata_draw_callback)(void*, int, t_symbol*, int, t_atom*); // Callback to perform drawing in plugdata

--- a/pdlua.h
+++ b/pdlua.h
@@ -43,9 +43,8 @@ typedef struct _pdlua_gfx
     char current_color[10]; // Keep track of current color
     
     // Variables to keep track of mouse button state and drag position
-    int mouse_drag_x, mouse_drag_y, mouse_down;
+    int mouse_x, mouse_y, mouse_down;
     int first_draw;
-    
 #else
     int current_layer;
     void(*plugdata_draw_callback)(void*, int, t_symbol*, int, t_atom*); // Callback to perform drawing in plugdata

--- a/pdlua_gfx.h
+++ b/pdlua_gfx.h
@@ -149,6 +149,14 @@ void pdlua_gfx_mouse_drag(t_pdlua *o, int x, int y) {
     pdlua_gfx_mouse_event(o, x, y, 3);
 }
 
+void pdlua_gfx_mouse_enter(t_pdlua *x, int xpos, int ypos) {
+    pdlua_gfx_mouse_event(x, xpos, ypos, 4);
+}
+
+void pdlua_gfx_mouse_exit(t_pdlua *x, int xpos, int ypos) {
+    pdlua_gfx_mouse_event(x, xpos, ypos, 5);
+}
+
 // Represents a path object, created with path.new(x, y)
 // for pd-vanilla, this contains all the points that the path contains. bezier curves are flattened out to points before being added
 // for plugdata, it only contains a unique ID to the juce::Path that this is mapped to
@@ -793,6 +801,7 @@ static int gfx_initialize(t_pdlua *obj)
     gfx->num_transforms = 0;
     gfx->num_layers = 0;
     gfx->layer_tags = NULL;
+    gfx->mouse_inside = 0;
     
     pdlua_gfx_repaint(obj, 0);
     return 0;


### PR DESCRIPTION
creating this PR mainly for discussion. tested with Pd vanilla

### questions
1. is the mechanism using parent canvas messages the correct way in Pd vanilla?
2. is the dragging behaviour expected that way (enter/exit are suppressed during drag, up and exit are reported outside on mouseup)?

### todos
* support plugdata and purr data

closes #61