### PR TITLE
Fixes Issue #72: Add Missing Third Parameter to lua_gc Function

### DIFF
--- a/pdlua.c
+++ b/pdlua.c
@@ -743,7 +743,7 @@ static void pdlua_free( t_pdlua *o /**< The object to destruct. */)
     
     // Collect garbage
     // If we don't do this here, it could potentially leak if no other pdlua objects are used afterwards
-    lua_gc(__L(), LUA_GCCOLLECT);
+    lua_gc(__L(), LUA_GCCOLLECT, 0);
     
     return;
 }

--- a/pdlua.c
+++ b/pdlua.c
@@ -728,7 +728,7 @@ static t_pdlua *pdlua_new
 }
 
 /** Pd object destructor. */
-static void pdlua_free( t_pdlua *o /**< The object to destruct. */)
+static void pdlua_free(t_pdlua *o /**< The object to destruct. */)
 {
     PDLUA_DEBUG("pdlua_free: stack top %d", lua_gettop(__L()));
     lua_getglobal(__L(), "pd");
@@ -743,7 +743,11 @@ static void pdlua_free( t_pdlua *o /**< The object to destruct. */)
     
     // Collect garbage
     // If we don't do this here, it could potentially leak if no other pdlua objects are used afterwards
-    lua_gc(__L(), LUA_GCCOLLECT, 0);
+    #if LUA_VERSION_NUM >= 504  // Lua 5.4 or newer
+        lua_gc(__L(), LUA_GCCOLLECT);
+    #else  // Lua 5.3 or older
+        lua_gc(__L(), LUA_GCCOLLECT, 0);
+    #endif
     
     return;
 }


### PR DESCRIPTION
This PR fixes Issue #72  by correcting the function call to `lua_gc`, which was missing the required third parameter.  

#### **Problem:**  
The `lua_gc` function in Purr Data was called with only two parameters, causing a compilation error when building with Lua 5.3. According to the [[official Lua 5.3 documentation](https://www.lua.org/manual/5.3/manual.html#lua_gc)](https://www.lua.org/manual/5.3/manual.html#lua_gc), `lua_gc` requires three parameters:  

```c
int lua_gc(lua_State *L, int what, int data);
```

#### **Solution:**  
- Updated the `lua_gc` function call by adding the missing third parameter (`data`).  
- Used `0` as the default value for `data`, ensuring safe execution without unintended side effects.  
- Ensured compatibility with Lua 5.3 to prevent further build failures.  

#### **Testing:**  
- Successfully built Purr Data after the fix.  
- Verified that the garbage collector functions as expected with the additional parameter.  

#### **Additional Context:**  
This issue likely arose due to an older Lua version where `lua_gc` required only two parameters. Updating to Lua 5.3 necessitated this fix.  

Let me know if any further changes are needed! 🚀