### PR TITLE
Fix for missing `glist_findrtext` in new Pd versions

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -59,7 +59,7 @@ jobs:
         path: build
 
   windows-build:
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       matrix:
         floatsize: [32, 64]

--- a/pdlua.c
+++ b/pdlua.c
@@ -59,8 +59,13 @@
 
 #include "pdlua_gfx.h"
 
+// function pointer type for signal_setmultiout (added with Pd 0.54)
 typedef void (*t_signal_setmultiout)(t_signal **, int); 
 static t_signal_setmultiout g_signal_setmultiout;
+
+// function pointer type for glist_getrtext/glist_findrtext (changes with Pd 0.56)
+typedef t_rtext *(*t_glist_rtext)(t_glist *, t_text *);
+static t_glist_rtext g_glist_getrtext;
 
 // This used to be in s_stuff.h, but not anymore since 0.55.1test1.
 int sys_trytoopenone(const char *dir, const char *name, const char* ext,
@@ -1315,7 +1320,7 @@ static int pdlua_set_arguments(lua_State *L)
             if (redraw) {
                 // update the text in the object box; this makes sure that
                 // the arguments in the display are what we just set
-                t_rtext *y = glist_findrtext(o->canvas, x);
+                t_rtext *y = g_glist_getrtext(o->canvas, x);
                 rtext_retext(y);
                 // redraw the object and its iolets (including incident
                 // cord lines), in case the object box size has changed
@@ -3042,7 +3047,7 @@ void pdlua_setup(void)
 #endif
     post(luaversionStr);
 
-// multichannel handling copied from https://github.com/Spacechild1/vstplugin/blob/3f0ed8a800ea238bf204a2ead940b2d1324ac909/pd/src/vstplugin~.cpp#L4122-L4136
+// compatibility handling copied from https://github.com/Spacechild1/vstplugin/blob/3f0ed8a800ea238bf204a2ead940b2d1324ac909/pd/src/vstplugin~.cpp#L4122-L4136
 #ifdef _WIN32
     // get a handle to the module containing the Pd API functions.
     // NB: GetModuleHandle("pd.dll") does not cover all cases.
@@ -3052,12 +3057,27 @@ void pdlua_setup(void)
             (LPCSTR)&pd_typedmess, &module)) {
         g_signal_setmultiout = (t_signal_setmultiout)(void *)GetProcAddress(
             module, "signal_setmultiout");
+        g_glist_getrtext = (t_glist_rtext)(void *)GetProcAddress(module, "glist_getrtext");
+        if (!g_glist_getrtext)
+            g_glist_getrtext = (t_glist_rtext)(void *)GetProcAddress(module, "glist_findrtext");
     }
 #else
     // search recursively, starting from the main program
     g_signal_setmultiout = (t_signal_setmultiout)dlsym(
         dlopen(NULL, RTLD_NOW), "signal_setmultiout");
+    g_glist_getrtext = (t_glist_rtext)dlsym(
+        dlopen(NULL, RTLD_NOW), "glist_getrtext");
+    if (!g_glist_getrtext)
+        g_glist_getrtext = (t_glist_rtext)dlsym(
+            dlopen(NULL, RTLD_NOW), "glist_findrtext");
 #endif
+
+    // check if g_glist_getrtext was loaded successfully
+    if (!g_glist_getrtext) {
+        pd_error(NULL, "pdlua: failed to load pd's glist_getrtext/glist_findrtext functions");
+        pd_error(NULL, "pdlua: loader will not be registered!");
+        return;
+    }
 
     pdlua_proxyinlet_setup();
     PDLUA_DEBUG("pdlua pdlua_proxyinlet_setup done", 0);


### PR DESCRIPTION
this uses the mechanism we already had in place for the multichannel handling.

uses the new `glist_getrtext` if present and otherwise falls back to the previous `glist_findrtext`

tested with Pd vanilla for official `0.55-2` build and current `master` including the change.