### PR TITLE
replace sys_trytoopenone() with public open_via_path()

### DIFF
--- a/pdlua.c
+++ b/pdlua.c
@@ -62,13 +62,9 @@
 typedef void (*t_signal_setmultiout)(t_signal **, int); 
 static t_signal_setmultiout g_signal_setmultiout;
 
-// This used to be in s_stuff.h, but not anymore since 0.55.1test1.
-int sys_trytoopenone(const char *dir, const char *name, const char* ext,
-    char *dirresult, char **nameresult, unsigned int size, int bin);
-
 // Check for absolute filenames in the second argument. Otherwise,
-// sys_trytoopenone will happily prepend the given path anyway.
-#define trytoopenone(dir, name, ...) sys_trytoopenone(sys_isabsolutepath(name) ? "" : dir, name, __VA_ARGS__)
+// open_via_path will happily prepend the given path anyway.
+#define trytoopenone(dir, name, ...) open_via_path(sys_isabsolutepath(name) ? "" : dir, name, __VA_ARGS__)
 
 #ifdef PDINSTANCE
 


### PR DESCRIPTION
not sure what the side effects here might be - but since we get warnings in Pd0.56 (probably coming in a few weeks) for every call of `sys_trytoopenone()`, it might be reasonable to use an approach with `open_via_path()`, which is part of Pd's public API ...?