### PR TITLE
build on windows-latest

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -59,7 +59,7 @@ jobs:
         path: build
 
   windows-build:
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       matrix:
         floatsize: [32, 64]


### PR DESCRIPTION
new windows builds fail because `windows-2019` is deprecated. this now simply uses `windows-latest` (similar to how we already use `ubuntu-latest` and `macos-latest`).