### PR TITLE
use clock_getlogicaltime to avoid deprecation warning for clock_getsystime

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -59,7 +59,7 @@ jobs:
         path: build
 
   windows-build:
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       matrix:
         floatsize: [32, 64]

--- a/pdlua.c
+++ b/pdlua.c
@@ -1886,7 +1886,7 @@ static int pdlua_clock_free(lua_State *L)
 
 static int pdlua_systime(lua_State *L)
 {
-    lua_pushnumber(L, clock_getsystime());
+    lua_pushnumber(L, clock_getlogicaltime());
     return 1;
 }
 


### PR DESCRIPTION
this replaces the deprecated call. both are functionally identical - see:

https://github.com/pure-data/pure-data/blob/6dfd92aea7d22885f87c7d0a5e2604500271bfc2/src/m_sched.c#L145-L153

the `sys_vgui` -> `pdgui_vmess` replacements to avoid more deprecation warnings are all handled in:
* #74