### PR TITLE
WebPdL2Ork support for graphics

### DIFF
--- a/pd.lua
+++ b/pd.lua
@@ -56,7 +56,6 @@ pd._constructor = function (name, atoms)
   if nil ~= pd._classes[fullpath] then
     local o = pd._classes[fullpath]:new():construct(name, atoms)
     if o then
-      pd._objects[o._object] = o
       return o._object
     end
   end
@@ -360,6 +359,7 @@ function pd.Class:construct(sel, atoms)
   if self:initialize(sel, atoms) then
     pd._createinlets(self._object, self.inlets)
     pd._createoutlets(self._object, self.outlets)
+    pd._objects[self._object] = self
     if type(self.paint) == "function" then
         pd._creategui(self._object)
     end

--- a/pdlua.c
+++ b/pdlua.c
@@ -387,6 +387,11 @@ static void pdlua_proxyinlet_anything
     t_atom              *argv /**< The atoms in the message. */
 )
 {
+#ifdef WEBPDL2ORK
+    if(s == gensym("mouse_event"))
+        pdlua_gfx_mouse_event(p->owner, atom_getint(&argv[0]), atom_getint(&argv[1]), atom_getint(&argv[2]));
+    else
+#endif
     pdlua_dispatch(p->owner, p->id, s, argc, argv);
 }
 
@@ -1457,6 +1462,13 @@ static int pdlua_object_new(lua_State *L)
 #else
                 // NULL until plugdata overrides them with something useful
                 o->gfx.plugdata_draw_callback = NULL;
+#endif
+#ifdef WEBPDL2ORK
+                static int next_lua_id = 0;
+                if(strcmp(c->c_name->s_name, "pdlua") && strcmp(c->c_name->s_name, "pdluax"))
+                    o->lua_id = ++next_lua_id;
+                else
+                    o->lua_id = 0;
 #endif
                 
                 lua_pushlightuserdata(L, o);

--- a/pdlua.h
+++ b/pdlua.h
@@ -73,6 +73,9 @@ typedef struct pdlua
     t_class                 *pdlua_class;     // Holds our class pointer.
     t_class                 *pdlua_class_gfx; // Holds our gfx class pointer.
     t_signal                **sp;             // Array of signal pointers for multichannel audio.
+#ifdef WEBPDL2ORK
+    int                     lua_id;           // ID for WebPDL2ORK to track this object
+#endif
 } t_pdlua;
 
 lua_State* __L();


### PR DESCRIPTION
Add a few blocks of code to enable graphics support in WebPdL2Ork

- When compiling for WebPdL2Ork, record a unique id for each lua object (used by WebPdL2Ork to manage graphics calls)
- When compiling for WebPdL2Ork, accept mouse events using a mouse_event message
- When compiling for WebPdL2Ork, redirect vmess to webpdl2ork stub functions
- Add object to pd._objects map before calling _creategui. This prevents the object in the object map from being null while all of the graphics setup is going on (throughout both C and lua parts of the process) and allows repainting to occur.


These patches were designed to be as minimally disruptive as possible. Let me know if any changes should be made.